### PR TITLE
Feature: Dice Rolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Finally, start the Metro web server from the root of the project via `npm start`
 
 From the home screen, tap the "Start New Game" button. This will take you to the game setup menu, where you can provide game details for things like scoring, player count, and whether you need dice (and how many).
 
-Your responses will not clear if swapping pages, but be careful not to change options mid game, or you will potentially lose progress.
+Your responses will not clear if swapping pages, but be careful not to change critical options mid game, such as player count, or you will lose progress.
+
+On your turn, you can roll dice via the "Roll Dice" button to simulate a single or double dice role, depending on the requirements you set earlier. You can change between using 1, 2, or no dice at any time.
 
 **App is still in development!**
 

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -10,6 +10,7 @@ Please delete options that are not relevant.
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
 
 # Checklist:

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -1,7 +1,7 @@
 import "react-native-gesture-handler";
 import React from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { HomeScreen, GameSetupScreen } from "../screens";
+import { HomeScreen, GameSetupScreen, GamePlayScreen } from "../screens";
 
 export default function Navigation(props) {
   const { initialRoute } = props;
@@ -11,6 +11,7 @@ export default function Navigation(props) {
     <Navigator initialRouteName={initialRoute || "Home"}>
       <Screen name="Home" component={HomeScreen} />
       <Screen name="Setup" component={GameSetupScreen} />
+      <Screen name="Play" component={GamePlayScreen} />
     </Navigator>
   );
 }

--- a/src/screens/GamePlayScreen.js
+++ b/src/screens/GamePlayScreen.js
@@ -1,0 +1,108 @@
+import React, { useState } from "react";
+import { StyleSheet, View } from "react-native";
+import { Headline, Text, Button } from "react-native-paper";
+import { bindActionCreators } from "redux";
+import { connect } from "react-redux";
+
+import gameOptionsActions from "../actions/gameOptionsActions";
+import getDiceRoll from "../utilities/diceRoller";
+
+const GamePlayScreen = (props) => {
+  // Global State Props
+  const { needDice, diceCount } = props;
+
+  // Local State
+  const [diceRoll, setDiceRoll] = useState(null);
+
+  return (
+    <View style={styles.viewContainerScreen}>
+      <View style={styles.viewContainerLabelArea}>
+        <Headline>Player 1's Turn</Headline>
+      </View>
+
+      <View style={styles.viewDiceContainer}>
+        {needDice && !diceRoll && (
+          <View style={styles.viewDicePending}>
+            <Text style={styles.textDicePending}>?</Text>
+          </View>
+        )}
+        {diceRoll &&
+          diceRoll.map((die, index) => {
+            return (
+              <View key={"DIE" + index} style={styles.viewDice}>
+                {console.log(diceRoll)}
+                <Text style={styles.textDiceValue}>{die}</Text>
+              </View>
+            );
+          })}
+      </View>
+
+      {needDice && (
+        <View style={styles.viewContainerButtonArea}>
+          <Button onPress={() => setDiceRoll(getDiceRoll(diceCount))}>
+            Roll Dice
+          </Button>
+        </View>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  viewContainerScreen: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  viewContainerLabelArea: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  viewContainerButtonArea: {
+    flex: 1,
+  },
+  viewDiceContainer: {
+    flex: 2,
+    flexDirection: "row",
+  },
+  viewDice: {
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#fff8e6",
+    width: 100,
+    height: 100,
+    borderColor: "black",
+    borderWidth: 4,
+    borderRadius: 18,
+    margin: 8,
+  },
+  viewDicePending: {
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#282828",
+    width: 100,
+    height: 100,
+    borderColor: "black",
+    borderWidth: 4,
+    borderRadius: 18,
+    margin: 8,
+  },
+  textDiceValue: {
+    fontSize: 48,
+  },
+  textDicePending: {
+    fontSize: 48,
+    color: "white",
+  },
+});
+
+const mapStateToProps = (state) => {
+  return { ...state.gameOptions };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators({ ...gameOptionsActions }, dispatch);
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(GamePlayScreen);

--- a/src/screens/GamePlayScreen.js
+++ b/src/screens/GamePlayScreen.js
@@ -30,7 +30,6 @@ const GamePlayScreen = (props) => {
           diceRoll.map((die, index) => {
             return (
               <View key={"DIE" + index} style={styles.viewDice}>
-                {console.log(diceRoll)}
                 <Text style={styles.textDiceValue}>{die}</Text>
               </View>
             );

--- a/src/screens/GameSetupScreen.js
+++ b/src/screens/GameSetupScreen.js
@@ -14,6 +14,9 @@ import {
 } from "react-native-paper";
 
 const GameSetupScreen = (props) => {
+  // Navigation Helper
+  const { navigate } = props.navigation;
+
   // Global State Props
   const { needDice, playerCount, diceCount, scoringSystem } = props;
 
@@ -97,6 +100,10 @@ const GameSetupScreen = (props) => {
         />
         <Text>Points</Text>
       </View>
+
+      <Button mode="contained" color="orange" onPress={() => navigate("Play")}>
+        Start Game!
+      </Button>
     </ScrollView>
   );
 };

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -1,2 +1,3 @@
 export { default as HomeScreen } from "./HomeScreen";
 export { default as GameSetupScreen } from "./GameSetupScreen";
+export { default as GamePlayScreen } from "./GamePlayScreen";

--- a/src/utilities/diceRoller.js
+++ b/src/utilities/diceRoller.js
@@ -2,7 +2,7 @@ const getDiceRoll = (diceCount) => {
   const diceRolls = [];
 
   for (let i = 0; i < diceCount; i++) {
-    const randomDiceRoll = Math.floor(Math.random() * 6);
+    const randomDiceRoll = Math.floor(Math.random() * 6) + 1;
     diceRolls.push(randomDiceRoll);
   }
 


### PR DESCRIPTION
# Description

This branch adds the ability for players to roll dice on their turn. The dice count will either be one or two, depending on the options set in the game setup screen.

If the game does not require dice, no dice rolling options will be displayed. If dice _are_ needed, a placeholder image will be set until a player rolls for their turn.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
