### PR TITLE
Feature: Player Turn Rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ Finally, start the Metro web server from the root of the project via `npm start`
 
 From the home screen, tap the "Start New Game" button. This will take you to the game setup menu, where you can provide game details for things like scoring, player count, and whether you need dice (and how many).
 
-Your responses will not clear if swapping pages, but be careful not to change critical options mid game, such as player count, or you will lose progress.
+Your responses will not clear if swapping pages, but be careful not to change critical options mid game, such as player count, or you may lose progress for some players.
 
 On your turn, you can roll dice via the "Roll Dice" button to simulate a single or double dice role, depending on the requirements you set earlier. You can change between using 1, 2, or no dice at any time.
+
+Note: Dice rolls are not persistent, so screen/turn switches will reset the last known dice roll.
+
+When your turn is over, simply press the "End Turn" button, and the active player will be rotated to the next available person. The currently active player is displayed at the top of the gameplay screen for reference. When the final player is done, control will be given back to player 1.
 
 **App is still in development!**
 

--- a/src/actions/gameActions.js
+++ b/src/actions/gameActions.js
@@ -1,3 +1,7 @@
+const rotateActivePlayer = () => {
+  return { type: "ROTATE_ACTIVE_PLAYER" };
+};
+
 const toggleNeedDice = () => {
   return { type: "TOGGLE_NEED_DICE" };
 };
@@ -19,6 +23,7 @@ const setScoringSystem = (scoringSystem) => {
 };
 
 export default {
+  rotateActivePlayer,
   toggleNeedDice,
   addPlayer,
   subtractPlayer,

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -2,13 +2,19 @@ import "react-native-gesture-handler";
 import React from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { HomeScreen, GameSetupScreen, GamePlayScreen } from "../screens";
+import { darkTheme } from "../styles/theme";
 
 export default function Navigation(props) {
   const { initialRoute } = props;
   const { Navigator, Screen } = createNativeStackNavigator();
 
   return (
-    <Navigator initialRouteName={initialRoute || "Home"}>
+    <Navigator
+      initialRouteName={initialRoute || "Home"}
+      screenOptions={{
+        cardStyle: { backgroundColor: darkTheme.colors.background },
+      }}
+    >
       <Screen name="Home" component={HomeScreen} />
       <Screen name="Setup" component={GameSetupScreen} />
       <Screen name="Play" component={GamePlayScreen} />

--- a/src/reducers/gameOptionsReducer.js
+++ b/src/reducers/gameOptionsReducer.js
@@ -1,0 +1,49 @@
+export const initialGameOptionsState = {
+  playerCount: 1,
+  needDice: true,
+  diceCount: 1,
+  scoringSystem: {
+    points: true,
+  },
+};
+
+export const gameOptionsReducer = (state = initialGameOptionsState, action) => {
+  switch (action.type) {
+    case "TOGGLE_NEED_DICE":
+      return {
+        ...state,
+        needDice: !state.needDice,
+      };
+
+    case "ADD_PLAYER":
+      return {
+        ...state,
+        playerCount: state.playerCount + 1,
+      };
+
+    case "SUBTRACT_PLAYER":
+      if (state.playerCount - 1 < 1) {
+        return state;
+      } else {
+        return {
+          ...state,
+          playerCount: state.playerCount - 1,
+        };
+      }
+
+    case "SET_DICE_COUNT":
+      return {
+        ...state,
+        diceCount: action.payload,
+      };
+
+    case "SET_SCORING_SYSTEM":
+      return {
+        ...state,
+        scoringSystem: action.payload,
+      };
+
+    default:
+      return state;
+  }
+};

--- a/src/reducers/gameReducer.js
+++ b/src/reducers/gameReducer.js
@@ -1,4 +1,5 @@
 export const initialGameOptionsState = {
+  currentActivePlayer: 1,
   playerCount: 1,
   needDice: true,
   diceCount: 1,
@@ -7,8 +8,25 @@ export const initialGameOptionsState = {
   },
 };
 
-export const gameOptionsReducer = (state = initialGameOptionsState, action) => {
+const getNextPlayer = (currentPlayer, maxPlayers) => {
+  if (currentPlayer === maxPlayers) {
+    return 1;
+  } else {
+    return currentPlayer + 1;
+  }
+};
+
+export const gameReducer = (state = initialGameOptionsState, action) => {
   switch (action.type) {
+    case "ROTATE_ACTIVE_PLAYER":
+      return {
+        ...state,
+        currentActivePlayer: getNextPlayer(
+          state.currentActivePlayer,
+          state.playerCount,
+        ),
+      };
+
     case "TOGGLE_NEED_DICE":
       return {
         ...state,

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -1,8 +1,8 @@
 import { combineReducers } from "redux";
-import { gameOptionsReducer } from "./gameOptionsReducer";
+import { gameReducer } from "./gameReducer";
 
 const rootReducer = combineReducers({
-  gameOptions: gameOptionsReducer,
+  game: gameReducer,
 });
 
 export default rootReducer;

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -1,55 +1,8 @@
 import { combineReducers } from "redux";
+import { gameOptionsReducer } from "./gameOptionsReducer";
 
-export const initialState = {
-  playerCount: 1,
-  needDice: true,
-  diceCount: 1,
-  scoringSystem: {
-    points: true,
-  },
-};
-
-const gameOptionsReducer = (state = initialState, action) => {
-  switch (action.type) {
-    case "TOGGLE_NEED_DICE":
-      return {
-        ...state,
-        needDice: !state.needDice,
-      };
-
-    case "ADD_PLAYER":
-      return {
-        ...state,
-        playerCount: state.playerCount + 1,
-      };
-
-    case "SUBTRACT_PLAYER":
-      if (state.playerCount - 1 < 1) {
-        return state;
-      } else {
-        return {
-          ...state,
-          playerCount: state.playerCount - 1,
-        };
-      }
-
-    case "SET_DICE_COUNT":
-      return {
-        ...state,
-        diceCount: action.payload,
-      };
-
-    case "SET_SCORING_SYSTEM":
-      return {
-        ...state,
-        scoringSystem: action.payload,
-      };
-
-    default:
-      return state;
-  }
-};
-
-export default combineReducers({
+const rootReducer = combineReducers({
   gameOptions: gameOptionsReducer,
 });
+
+export default rootReducer;

--- a/src/screens/GamePlayScreen.js
+++ b/src/screens/GamePlayScreen.js
@@ -19,15 +19,26 @@ const getInitialDiceArray = (diceCount) => {
 
 const GamePlayScreen = (props) => {
   // Global State Props
-  const { needDice, diceCount } = props;
+  const { needDice, diceCount, currentActivePlayer } = props;
+
+  // Global Actions
+  const { rotateActivePlayer } = props;
 
   // Local State
   const [diceRoll, setDiceRoll] = useState(getInitialDiceArray(diceCount));
 
+  // Event Handlers
+  const handleEndTurn = () => {
+    setDiceRoll(getInitialDiceArray(diceCount));
+    rotateActivePlayer();
+  };
+
   return (
     <View style={styles.viewContainerScreen}>
       <View style={styles.viewContainerLabelArea}>
-        <Headline style={styles.headlineTitle}>Player 1's Turn</Headline>
+        <Headline style={styles.headlineTitle}>
+          Player {currentActivePlayer}'s Turn
+        </Headline>
       </View>
 
       <View style={styles.viewDiceContainer}>
@@ -64,7 +75,11 @@ const GamePlayScreen = (props) => {
             <Text style={styles.textRollDice}>Roll Dice</Text>
           </Button>
         )}
-        <Button style={styles.buttonEndTurn} mode="outlined">
+        <Button
+          style={styles.buttonEndTurn}
+          mode="outlined"
+          onPress={handleEndTurn}
+        >
           <Text style={styles.textEndTurn}>End Turn</Text>
         </Button>
       </View>

--- a/src/screens/GamePlayScreen.js
+++ b/src/screens/GamePlayScreen.js
@@ -13,7 +13,7 @@ const GamePlayScreen = (props) => {
   const { needDice, diceCount } = props;
 
   // Local State
-  const [diceRoll, setDiceRoll] = useState(null);
+  const [diceRoll, setDiceRoll] = useState(diceCount === 1 ? [0] : [0, 0]);
 
   return (
     <View style={styles.viewContainerScreen}>
@@ -22,12 +22,16 @@ const GamePlayScreen = (props) => {
       </View>
 
       <View style={styles.viewDiceContainer}>
-        {needDice && !diceRoll && (
-          <View style={styles.viewDicePending}>
-            <Text style={styles.textDicePending}>?</Text>
-          </View>
-        )}
-        {diceRoll &&
+        {needDice &&
+          diceRoll[0] === 0 &&
+          diceRoll.map((die) => {
+            return (
+              <View style={styles.viewDicePending}>
+                <Text style={styles.textDicePending}>?</Text>
+              </View>
+            );
+          })}
+        {diceRoll[0] !== 0 &&
           diceRoll.map((die, index) => {
             return (
               <View key={"DIE" + index} style={styles.viewDice}>

--- a/src/screens/GamePlayScreen.js
+++ b/src/screens/GamePlayScreen.js
@@ -8,12 +8,21 @@ import { darkTheme } from "../styles/theme";
 import gameOptionsActions from "../actions/gameOptionsActions";
 import getDiceRoll from "../utilities/diceRoller";
 
+// Helper Methods
+const getInitialDiceArray = (diceCount) => {
+  const initialDiceArray = [];
+  for (let i = 0; i < diceCount; i++) {
+    initialDiceArray.push(0);
+  }
+  return initialDiceArray;
+};
+
 const GamePlayScreen = (props) => {
   // Global State Props
   const { needDice, diceCount } = props;
 
   // Local State
-  const [diceRoll, setDiceRoll] = useState(diceCount === 1 ? [0] : [0, 0]);
+  const [diceRoll, setDiceRoll] = useState(getInitialDiceArray(diceCount));
 
   return (
     <View style={styles.viewContainerScreen}>
@@ -22,15 +31,18 @@ const GamePlayScreen = (props) => {
       </View>
 
       <View style={styles.viewDiceContainer}>
+        {/* Show black question-mark placeholder(s) when not rolled */}
         {needDice &&
           diceRoll[0] === 0 &&
-          diceRoll.map((die) => {
+          diceRoll.map((die, index) => {
             return (
-              <View style={styles.viewDicePending}>
+              <View key={"DIE" + index} style={styles.viewDicePending}>
                 <Text style={styles.textDicePending}>?</Text>
               </View>
             );
           })}
+
+        {/* Show dice roll results if dice rolled */}
         {diceRoll[0] !== 0 &&
           diceRoll.map((die, index) => {
             return (
@@ -41,8 +53,9 @@ const GamePlayScreen = (props) => {
           })}
       </View>
 
-      {needDice && (
-        <View style={styles.viewContainerButtonArea}>
+      <View style={styles.viewContainerButtonArea}>
+        {/* Show 'roll dice' button if needed */}
+        {needDice && (
           <Button
             style={styles.buttonRollDice}
             mode="contained"
@@ -50,8 +63,11 @@ const GamePlayScreen = (props) => {
           >
             <Text style={styles.textRollDice}>Roll Dice</Text>
           </Button>
-        </View>
-      )}
+        )}
+        <Button style={styles.buttonEndTurn} mode="outlined">
+          <Text style={styles.textEndTurn}>End Turn</Text>
+        </Button>
+      </View>
     </View>
   );
 };
@@ -66,6 +82,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     backgroundColor: darkTheme.colors.background,
+    paddingVertical: 64,
   },
   viewContainerLabelArea: {
     flex: 1,
@@ -74,6 +91,7 @@ const styles = StyleSheet.create({
   },
   viewContainerButtonArea: {
     flex: 1,
+    justifyContent: "flex-end",
   },
   viewDiceContainer: {
     flex: 2,
@@ -116,6 +134,17 @@ const styles = StyleSheet.create({
   },
   buttonRollDice: {
     width: 256,
+    marginBottom: 16,
+  },
+  buttonEndTurn: {
+    width: 256,
+    borderWidth: 2,
+    borderColor: darkTheme.colors.text,
+  },
+  textEndTurn: {
+    fontSize: 36,
+    lineHeight: 48,
+    color: darkTheme.colors.text,
   },
 });
 

--- a/src/screens/GamePlayScreen.js
+++ b/src/screens/GamePlayScreen.js
@@ -5,7 +5,7 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 
 import { darkTheme } from "../styles/theme";
-import gameOptionsActions from "../actions/gameOptionsActions";
+import gameActions from "../actions/gameActions";
 import getDiceRoll from "../utilities/diceRoller";
 
 // Helper Methods
@@ -149,11 +149,11 @@ const styles = StyleSheet.create({
 });
 
 const mapStateToProps = (state) => {
-  return { ...state.gameOptions };
+  return { ...state.game };
 };
 
 const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({ ...gameOptionsActions }, dispatch);
+  return bindActionCreators({ ...gameActions }, dispatch);
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(GamePlayScreen);

--- a/src/screens/GameSetupScreen.js
+++ b/src/screens/GameSetupScreen.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import gameOptionsActions from "../actions/gameOptionsActions";
+import gameActions from "../actions/gameActions";
 import { StyleSheet, View, ScrollView } from "react-native";
 import {
   Text,
@@ -157,11 +157,11 @@ const styles = StyleSheet.create({
 });
 
 const mapStateToProps = (state) => {
-  return { ...state.gameOptions };
+  return { ...state.game };
 };
 
 const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({ ...gameOptionsActions }, dispatch);
+  return bindActionCreators({ ...gameActions }, dispatch);
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(GameSetupScreen);


### PR DESCRIPTION
# Description

This branch adds player turn tracking and display; users can see whose turn it is, and players can end their turn (with a new button on the game play screen), passing control to another person. 

Dice rolls will reset upon switching players. The active player is stored in global state, so changing settings mid-game is relatively safe.

Also, the white flashing between screen transitions bug is patched.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
